### PR TITLE
Changing ConnectAsync methods to extensions methods. (#2)

### DIFF
--- a/RxSockets/Extensions/RxExtensions.cs
+++ b/RxSockets/Extensions/RxExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RxSockets
+{
+    public static class RxExtensions
+    {
+        public static IRxSocketServer CreateRxSocketServer(this IPEndPoint endPoint, int backLog = 10) =>
+            CreateRxSocketServer(endPoint, NullLogger<RxSocketServer>.Instance, backLog);
+
+        public static IRxSocketServer CreateRxSocketServer(this IPEndPoint endPoint, ILogger<RxSocketServer> logger, int backLog = 10)
+        {
+            if (endPoint == null)
+                throw new ArgumentNullException(nameof(endPoint));
+            if (backLog < 0)
+                throw new Exception($"Invalid backLog: {backLog}.");
+            logger.LogInformation($"Creating server at EndPoint: {endPoint}.");
+            var socket = Utilities.CreateSocket();
+            socket.Bind(endPoint);
+            socket.Listen(backLog);
+            logger.LogTrace("Listening.");
+            return new RxSocketServer(socket, logger);
+        }
+        public static Task<IRxSocketClient> ConnectRxSocketClientAsync(this IPEndPoint endPoint, int timeout = -1, CancellationToken ct = default)
+            => ConnectRxSocketClientAsync(endPoint, NullLogger<RxSocketClient>.Instance, timeout, ct);
+
+        public static async Task<IRxSocketClient> ConnectRxSocketClientAsync(this IPEndPoint endPoint, ILogger<RxSocketClient> logger, int timeout = -1, CancellationToken ct = default)
+        {
+            var socket = await SocketConnector.ConnectAsync(endPoint, logger, timeout, ct).ConfigureAwait(false);
+            return new RxSocketClient(socket, logger);
+        }
+    }
+}

--- a/RxSockets/RxSocketClient.cs
+++ b/RxSockets/RxSocketClient.cs
@@ -8,12 +8,13 @@ using System.Reactive.Concurrency;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Reactive.Disposables;
+using RxSockets;
 
 #nullable enable
 
 namespace RxSockets
 {
-    public interface IRxSocketClient: IDisposable
+    public interface IRxSocketClient : IDisposable
     {
         bool Connected { get; }
         void Send(byte[] buffer, int offset = 0, int length = 0);
@@ -95,23 +96,14 @@ namespace RxSockets
 
             });
         }
-
+        public static Task<IRxSocketClient> ConnectAsync(IPEndPoint endPoint, int timeout = -1, CancellationToken ct = default) => RxExtensions.ConnectRxSocketClientAsync(endPoint, timeout, ct);
+        public static async Task<IRxSocketClient> ConnectAsync(IPEndPoint endPoint, ILogger<RxSocketClient> logger, int timeout = -1, CancellationToken ct = default) => await RxExtensions.ConnectRxSocketClientAsync(endPoint, logger, timeout, ct);
         public void Send(byte[] buffer, int offset = 0, int length = 0)
         {
             if (length == 0)
                 length = buffer.Length;
             Logger.LogTrace($"Sending {length} bytes.");
             Socket.Send(buffer, offset, length, SocketFlags.None);
-        }
-
-        // static!
-        public static Task<IRxSocketClient> ConnectAsync(IPEndPoint endPoint, int timeout = -1, CancellationToken ct = default)
-            => ConnectAsync(endPoint, NullLogger<RxSocketClient>.Instance, timeout, ct);
-
-        public static async Task<IRxSocketClient> ConnectAsync(IPEndPoint endPoint, ILogger<RxSocketClient> logger, int timeout = -1, CancellationToken ct = default)
-        {
-            var socket = await SocketConnector.ConnectAsync(endPoint, logger, timeout, ct).ConfigureAwait(false);
-            return new RxSocketClient(socket, logger);
         }
 
         public void Dispose()


### PR DESCRIPTION
* Changing ConnectAsync methods to extensions methods.

* Changing RxExtensions methods names.

* Backward compatibility

* Move RxExtensions file.

* ... and unify namespace.

* Fix namespace.